### PR TITLE
Allow control words to take arguments

### DIFF
--- a/src/hebi/basic/_macro_.py
+++ b/src/hebi/basic/_macro_.py
@@ -1,1 +1,1 @@
-from ..bootstrap import def_, import_, from_, if_, raise_, mask
+from ..bootstrap import def_, import_, from_, if_, raise_, mask, begin

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -13,17 +13,17 @@ hissp.basic.._macro_.deftype: TestNative pass: TestCase
         self.assertEqual:
             pass:  # Example based on cascade macro.
                 lambda: pass: thing thing_sym : :* calls
-                    !mask:pass:lambda: pass: : _:thing_sym _:thing
+                    !mask:pass:lambda: pass: : :,:thing_sym :,:thing
                         print: "Hi!"  # Builtin symbol.
                         greet: "World!"  # Local symbol.
-                        __:map:  # Splice
+                        :,@:map:  # Splice
                             lambda: pass:call
                                 !mask:pass:  # Nested !mask.
-                                    _:operator..getitem: call 0
-                                    _:thing_sym
-                                    __:operator..getitem: call slice: 1 None
+                                    :,:operator..getitem: call 0
+                                    :,:thing_sym
+                                    :,@:operator..getitem: call slice: 1 None
                             calls
-                        _:thing_sym
+                        :,:thing_sym
                 : :*
                 quote:pass: spam foo
                     frobnicate: 7 24
@@ -40,13 +40,13 @@ hissp.basic.._macro_.deftype: TestNative pass: TestCase
             hebi.bootstrap..if_:
                 : :* quote:pass:
                     ('a'<'b')
-                    pass:
+                    :then:
                         print: "less"
-                    elif: ('a'>'b')
+                    :elif: ('a'>'b')
                         print: "more"
-                    elif: ('a'=='b')
+                    :elif: ('a'=='b')
                         print: "equal"
-                    else:
+                    :else:
                         print: "nan"
             quote:hebi.bootstrap.._if_:
                 ('a'<'b')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -229,8 +229,34 @@ if
     ('hebi.basic.._macro_.spam', 'eggs', 'hebi.basic.._macro_.quux'),
     'hebi.basic.._macro_.if_',
     'hebi.basic.._macro_.if_',
-]
+],
 
+'''
+!mask:pass:lambda: :: :,:thing_sym :,:thing
+    print: "Hi!"  # Builtin symbol.
+    greet: "World!"  # Local symbol.
+    :,@:map:  # Splice
+        lambda: pass:call
+            !mask:pass:  # Nested !mask.
+                :,:operator..getitem: call 0
+                :,:thing_sym
+                :,@:operator..getitem: call slice: 1 None
+        calls
+    :,:thing_sym
+''':[
+('hebi.basic.._macro_.mask',
+   (('lambda', (':', (':,', 'thing_sym'), (':,', 'thing')),
+     ('print', '("Hi!")'),
+     ('greet', '("World!")'),
+     (':,@', ('map',
+       ('lambda', ('call',),
+        ('hebi.basic.._macro_.mask',
+         ((':,', ('operator..getitem', 'call', 0)),
+          (':,', 'thing_sym'),
+          (':,@', ('operator..getitem', 'call', ('slice', 1, 'None')))))),
+       'calls')),
+     (':,', 'thing_sym')),))
+],
 }
 
 class TestParser(TestCase):


### PR DESCRIPTION
Also modify some macros to use this feature.

Adds the `begin:` macro. (Named for Scheme's `PROGN` equivalent.)

Resolves #16.

Resolves #9 too.