### PR TITLE
Implement and test !loop: macro

### DIFF
--- a/src/hebi/basic/_macro_.py
+++ b/src/hebi/basic/_macro_.py
@@ -12,4 +12,5 @@ from ..bootstrap import (
     with_,
     assert_,
     let,
+    loop,
 )

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -276,7 +276,14 @@ deftype: TestLet pass:TestCase
                 {'b':22,'c':33}
                 [a, b, c]
 
-
+deftype: TestLoop pass:TestCase
+    test_loop lambda: self:
+        self.assertEqual:
+            'cba'
+            !loop: recur: xs 'abc'  ys ''
+                if: xs
+                    :then: (recur(xs[:-1], ys + xs[-1]))
+                    :else: ys
 
 # !let: :.: :syms: a b
 #     !let: ns types..SimpleNamespace:


### PR DESCRIPTION
Trampolined loops for TCO recursion, pretty much copied from Drython. (Plus a macro to write the lambda). The loop macro defines a function that can call itself. The initial syntax is similar to `def`.

```
!loop: <name>: [<arg> <default>]*
    <body>
```
Return a call to `<name>` to recur. See the test for an example.