### PR TITLE
For loop and tests

### DIFF
--- a/src/hebi/basic/_macro_.py
+++ b/src/hebi/basic/_macro_.py
@@ -13,4 +13,5 @@ from ..bootstrap import (
     assert_,
     let,
     loop,
+    try_,
 )

--- a/src/hebi/basic/_macro_.py
+++ b/src/hebi/basic/_macro_.py
@@ -14,4 +14,5 @@ from ..bootstrap import (
     let,
     loop,
     try_,
+    for_,
 )

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -599,13 +599,12 @@ class LabeledBreak(BaseException):
 
 
 class LabeledResultBreak(LabeledBreak):
-    def __init__(self, result=None, *results, **label):
-        assert set(label.keys()) <= {'label'}
+    def __init__(self, result=None, *results, label):
         if results:
             self.result = (result,) + results
         else:
             self.result = result
-        LabeledBreak.__init__(self, label.get('label', None))
+        LabeledBreak.__init__(self, label)
 
 
 class Break(LabeledResultBreak):

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -316,7 +316,7 @@ def try_(expr, *handlers):
     else_ = ()
     finally_ = ()
     except_ = []
-    for handler in partition(handlers):
+    for handler in handlers:
         if handler[0] == ':except':
             if len(handler) > 3 and handler[2] == ':as':
                 arg = handler[3]
@@ -328,14 +328,14 @@ def try_(expr, *handlers):
         elif handler[0] == ':else':
             if else_:
                 raise SyntaxError(handler)
-            else_ = _thunk('lambda',(),handler[1:],),
+            else_ = 'else_', _thunk(*handler[1:]),
         elif handler[0] == ':finally':
             if finally_:
                 raise SyntaxError(handler)
-            finally_ = _thunk('lambda',(),handler[1:],),
+            finally_ = 'finally', _thunk(*handler[1:]),
         else:
             raise SyntaxError(handler)
-    return (BOOTSTRAP + '_try_', _thunk(*expr), *except_, *else_, *finally_,)
+    return (BOOTSTRAP + '_try_', _thunk(expr), *except_, ':', *else_, *finally_,)
 
 
 def mask(form):
@@ -573,7 +573,7 @@ def _loop(f):
 def loop(start, *body):
     """
     !loop: recur: xs 'abc'  ys ''
-        if: xs :then: (recur(xs[:-1], ys+xs[-1]))
+        if: xs :then: recur(xs[:-1], ys+xs[-1])
             :else: ys
     """
     return (

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -537,7 +537,9 @@ def _quote_target(target):
     return (BOOTSTRAP + 'entuple', *_quote_tuple(iter(target)))
 
 
-def let(target, value, *body):
+def let(target, from_, value, *body):
+    if from_ != ':from':
+        raise SyntaxError('Missing :from in !let.')
     if type(target) is tuple:
         parameters = tuple(_flatten_tuples(target))
         return (
@@ -639,7 +641,7 @@ def for_(*exprs):
     if type(bindings[0]) is str:
         body = (tuple(bindings), *body)
     else:
-        body = ('xAUTO0_',), ('hebi.basic.._macro_.let', *bindings, 'xAUTO0_', *body),
+        body = ('xAUTO0_',), ('hebi.basic.._macro_.let', *bindings, ':from', 'xAUTO0_', *body),
     return (
         BOOTSTRAP + '_for_',
         iterable,

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -149,17 +149,17 @@ deftype: TestOr pass:TestCase
                     or: x y z
 
 deftype: TestLet pass:TestCase
-    test_1 lambda: self:
+    test_single lambda: self:
         self.assertEqual:
             42
-            !let: a (40 + 2)
+            !let: a :from (40 + 2)
                 a
     test_2 lambda: self:
         self.assertEqual:
             24
             !let:
                 :,: a b
-                [20, 4]
+                :from [20, 4]
                 (a + b)
     test_nested lambda: self:
         self.assertEqual:
@@ -167,28 +167,35 @@ deftype: TestLet pass:TestCase
             !let:
                 :,: :,: x1 y1
                     :,: x2 y2
-                [[1, 10],
-                 [6, 60]]
+                :from [[1, 10],
+                       [6, 60]]
                 [x1 - x2, y1 - y2]
     test_ignored lambda: self:
         self.assertEqual:
             [1, 4, 5]
             !let:
                 :,: a _ _ d e
-                [1, 2, 3, 4, 5]
+                :from [1, 2, 3, 4, 5]
                 [a, d, e]
     test_list lambda: self:
         self.assertEqual:
             [1, 2, [3, 4, 5]]
             !let:
                 :,: a b :list c
-                [1, 2, 3, 4, 5]
+                :from [1, 2, 3, 4, 5]
                 [a, b, c]
+    test_iter lambda: self:
+        self.assertEqual:
+            ['a', 'c', 'b', 'd', 'e']
+            !let:
+                :,: a b :iter c
+                :from 'abcde'
+                [a, next(c), b, *c]
     test_mapping lambda: self:
         self.assertEqual:
             ['one', 'bar']
             !let: :=: a 1  b 'foo'
-                {1: 'one', 'foo': 'bar'}
+                :from {1: 'one', 'foo': 'bar'}
                 [a, b]
     test_nested_mapping lambda: self:
         self.assertEqual:
@@ -199,16 +206,16 @@ deftype: TestLet pass:TestCase
                     2
                     :=: c 'bar'
                     3
-                {1: 'one',
-                 2: {'foo': 'spam'},
-                 3: {'bar': 'eggs'}}
+                :from {1: 'one',
+                       2: {'foo': 'spam'},
+                       3: {'bar': 'eggs'}}
                 [a, b, c]
     test_too_many lambda: self:
         self.assertEqual:
             [1, 2, 3]
             !let:
                 :,: a b c
-                [1, 2, 3, 4, 5]
+                :from [1, 2, 3, 4, 5]
                 [a, b, c]
     test_as lambda: self:
         self.assertEqual:
@@ -216,13 +223,13 @@ deftype: TestLet pass:TestCase
             !let:
                 :,: :,: x1 y1 :as point1
                     :,: x2 y2 :as point2
-                [[3, 7], 'xy']
+                :from [[3, 7], 'xy']
                 [point1, x1, y1, point2, x2, y2]
     test_mapping_as lambda: self:
         self.assertEqual:
             ['spam', {1:'spam'}]
             !let: :=: s 1 :as d
-                {1:'spam'}
+                :from {1:'spam'}
                 [s, d]
     test_nested_mixed lambda: self:
         self.assertEqual:
@@ -230,14 +237,14 @@ deftype: TestLet pass:TestCase
             !let:
                 :=: :,: a b :as s
                     1
-                {1:'ab'}
+                :from {1:'ab'}
                 [a, b, s]
         self.assertEqual:
             [[{1:'ab'}], 'ab']
             !let:
                 :,: :=: s 1
                     :as d
-                [{1:'ab'}]
+                :from [{1:'ab'}]
                 [d, s]
         self.assertEqual:
             ['a', 'b', [{1:'ab'}], 'ab']
@@ -246,26 +253,26 @@ deftype: TestLet pass:TestCase
                     :=: :,: a b :as s
                         1
                     :as d
-                [{1:'ab'}]
+                :from [{1:'ab'}]
                 [a, b, d, s]
         self.assertEqual:
             'spam'
             !let:
                 :=: :,: :=: s 2
                     1
-                {1:[{2:'spam'}]}
+                :from {1:[{2:'spam'}]}
                 s
     test_strs lambda: self:
         self.assertEqual:
             [1, 2, 3]
             !let: :=: :strs: a b c
-                {'a':1, 'b':2, 'c':3}
+                :from {'a':1, 'b':2, 'c':3}
                 [a, b, c]
     test_default lambda: self:
         self.assertEqual:
             ['A','b','C','d']
             !let: :=: a 1  b 2  c 3  d 4  :default: a 'A'  b 'X'  c 'C'
-                {2:'b', 4:'d'}
+                :from {2:'b', 4:'d'}
                 [a,b,c,d]
     test_default_strs lambda: self:
         self.assertEqual:
@@ -273,7 +280,7 @@ deftype: TestLet pass:TestCase
             !let:
                 :=: :strs: a b c
                     :default: a ('a'+'b')
-                {'b':22,'c':33}
+                :from {'b':22,'c':33}
                 [a, b, c]
 
 deftype: TestLoop pass:TestCase
@@ -285,7 +292,7 @@ deftype: TestLoop pass:TestCase
                     :then: (recur(xs[:-1], ys + xs[-1]))
                     :else: ys
     test_try_iter lambda: self:
-        !let: xs []
+        !let: xs :from []
             !loop: recur: it iter:'abc'
                 try: .append: xs .upper:next:it
                     :except: StopIteration
@@ -294,14 +301,14 @@ deftype: TestLoop pass:TestCase
                 ['A', 'B', 'C']
                 xs
     test_for lambda: self:
-        !let: xs []
+        !let: xs :from []
             for: c :in 'abc'
                 .append: xs .upper:c
             self.assertEqual:
                 ['A', 'B', 'C']
                 xs
     test_for_bind lambda: self:
-        !let: xs []
+        !let: xs :from []
             for: :,: c i
                 :in zip: 'abc' [1,2,3]
                 xs.append:(c*i)

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -284,6 +284,16 @@ deftype: TestLoop pass:TestCase
                 if: xs
                     :then: (recur(xs[:-1], ys + xs[-1]))
                     :else: ys
+    test_try_iter lambda: self:
+        !let: xs []
+            !loop: recur: it iter:'abc'
+                try: .append: xs .upper:next:it
+                    :except: StopIteration
+                    :else: recur:it
+            self.assertEqual:
+                ['A', 'B', 'C']
+                xs
+
 
 # !let: :.: :syms: a b
 #     !let: ns types..SimpleNamespace:

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -293,6 +293,23 @@ deftype: TestLoop pass:TestCase
             self.assertEqual:
                 ['A', 'B', 'C']
                 xs
+    test_for lambda: self:
+        !let: xs []
+            for: c :in 'abc'
+                .append: xs .upper:c
+            self.assertEqual:
+                ['A', 'B', 'C']
+                xs
+    test_for_bind lambda: self:
+        !let: xs []
+            for: :,: c i
+                :in zip: 'abc' [1,2,3]
+                xs.append:(c*i)
+            self.assertEqual:
+                ['a','bb','ccc']
+                xs
+
+
 
 
 # !let: :.: :syms: a b

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -316,7 +316,7 @@ deftype: TestLoop pass:TestCase
                 ['a','bb','ccc']
                 xs
 
-
+# TODO: test break, continue, for/do/else, label, labeled result, !begin, try
 
 
 # !let: :.: :syms: a b


### PR DESCRIPTION
Ports the `for` macro from Drython, but not everything works yet. `break` and `continue` will need their own macros. These should be able to take labels and results like Drython, and unlike Python (but we need them because we have no `return` statement).

The `for` macro uses `!let`'s destructuring syntax. This is more powerful than Python's version. To make `!let` more consistent with `for`, `!let` has been changed to require a `:from` control word where `for` uses its `:in` control word.

Also some fixes for the try macro, but it still needs more tests.