### PR TITLE
Double unquotes

### DIFF
--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -351,10 +351,10 @@ def mask(form):
             return 'quote', form
         if form[0] == ':,':
             return form[1]
+        if form[0] == 'hebi.basic.._macro_.mask':
+            return mask(mask(form[1]))
         return (
-            ('lambda',(':',':*','xAUTO0_',),'xAUTO0_',),
-            ':',
-            *chain.from_iterable(_mask(form)),
+            BOOTSTRAP + 'entuple', ':', *chain.from_iterable(_mask(form)),
         )
     if case is str and not form.startswith(':'):
         return 'quote', _qualify(form)
@@ -371,6 +371,8 @@ def _mask(forms):
                 yield ':?', form[1]
             elif form[0] == ':,@':
                 yield ':*', form[1]
+            elif form[0] == 'hebi.basic.._macro_.mask':
+                yield ':?', mask(mask(form[1]))
             else:
                 yield ':?', mask(form)
         else:

--- a/src/hebi/parser.py
+++ b/src/hebi/parser.py
@@ -29,15 +29,15 @@ TOKEN = re.compile(r"""(?x)
 |(?P<unary>(?:
     !?  # basic macro?
     [.\w]+  # unary symbol
-    |:[^ \r\n"')\]}]*  # unary control word
+    |:[^: \r\n"')\]}]*  # unary control word
     ):(?=[^ \r\n]))  # lack of space after ending colon makes it unary
 |(?P<multiary>(?:
     !?  # basic macro?
     [.\w]+  # multiary symbol
-    |:[^ \r\n"')\]}]*  # multiary control word
+    |:[^: \r\n"')\]}]*  # multiary control word
     ):(?=[ \r\n]))  # space after ending colon makes in multiary
 
-|(?P<controlword>:[^ \r\n"')\]}]*)
+|(?P<controlword>:[^: \r\n"')\]}]*)
 |(?P<symbol>[^ \r\n"')\]}]+)
 |(?P<error>.|\n)
 """)

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -51,6 +51,52 @@ deftype: TestNative pass:TestCase
                 quote:pass: spam foo
                     frobnicate: 7 24
                     reticulate: spline
+    test_simple_double_unquote lambda: self:
+        self.assertEqual:
+            1
+            !let: a :be 1
+                !mask:!mask::,::,:a
+    test_double_unquote lambda: self:
+        self.assertEqual:
+            quote:pass:
+                hebi.bootstrap..entuple: : :? 1  :? 2
+                3
+            !let: a :be 1
+                !mask:pass:
+                    !mask:pass: :,::,:a 2
+                    3
+    test_simple_alternate_double_unquote lambda: self:
+        self.assertEqual:
+            2
+            !let: a :be 2
+                !mask::,:!mask::,:a
+    test_alternate_double_unquote lambda: self:
+        self.assertEqual:
+            quote:pass: 0 pass: 1 2
+            !let: a :be 2
+                !mask:pass:
+                    0
+                    :,:!mask:pass: 1 :,:a
+    test_simple_double_mask_unquote lambda: self:
+        self.assertEqual:
+            quote:builtins..print
+            !let: print :be 3
+                !mask:!mask::,:print
+    test_double_mask_unquote lambda: self:
+        self.assertEqual:
+            quote:pass:
+                0
+                hebi.bootstrap..entuple:
+                    : :? 1
+                    :? 2
+                    :? builtins..print
+            !let: print :be 3
+                !mask:pass:
+                    0
+                    !mask:pass:
+                        1
+                        2
+                        :,:print
     test_elif lambda: self:
         self.assertEqual:
             quote:hebi.bootstrap.._if_:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -271,6 +271,7 @@ if
  (':default', 'a', "(('a'+'b'))"),
  )
 ],
+
 '''
 foo:
     [1, 2,
@@ -283,6 +284,19 @@ bar: 1
  'x'),
 ('bar', 1),
 ],
+
+'''
+!mask:!mask::,::,:a
+:foo:bar
+:foo :bar
+''': [
+    ('hebi.basic.._macro_.mask',
+     ('hebi.basic.._macro_.mask',
+      (':,',
+       (':,','a')))),
+    (':foo','bar'),
+    ':foo', ':bar',
+]
 }
 
 BAD_INDENTS = ['''


### PR DESCRIPTION
closes #4 

Fixes double-unquote issue in `!mask`. More thorough tests.
Also fixes an issue in the lexer that prevented unary control words from working.