### PR TITLE
Def to attr

### DIFF
--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -80,7 +80,8 @@ def def_(name, *body):
                 continue
             if _is_str(expr):
                 doc = expr
-                body = *ibody,
+            else:
+                ibody = expr, *ibody
             break
         name = _expand_ns(name)
         return (
@@ -90,7 +91,7 @@ def def_(name, *body):
                 decorators,
                 (BOOTSTRAP + 'function',
                  ('quote', name,),
-                 ('lambda', tuple(args), *body),
+                 ('lambda', tuple(args), *ibody),
                  doc)),
         )
     if len(body) == 1:
@@ -119,6 +120,8 @@ def _decorate(decorators, function):
 
 
 def _expand_ns(name):
+    if type(name) is tuple:
+        return (_expand_ns(name[0]), *name[1:])
     if type(name) is str and name.startswith(':'):
         name = '_ns_.' + name[1:]
     return name

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -122,8 +122,8 @@ def _decorate(decorators, function):
 def _expand_ns(name):
     if type(name) is tuple:
         return (_expand_ns(name[0]), *name[1:])
-    if type(name) is str and name.startswith(':'):
-        name = '_ns_.' + name[1:]
+    if type(name) is str and name.startswith('.'):
+        name = '_ns_' + name
     return name
 
 

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -74,7 +74,7 @@ def def_(name, *body):
         doc = None
         decorators = []
         ibody = iter(body)
-        for expr in body:
+        for expr in ibody:
             if expr == ":@":
                 decorators.append(next(ibody))
                 continue
@@ -82,6 +82,7 @@ def def_(name, *body):
                 doc = expr
                 body = *ibody,
             break
+        name = _expand_ns(name)
         return (
             'hebi.basic.._macro_.def_',
             name,
@@ -93,6 +94,15 @@ def def_(name, *body):
                  doc)),
         )
     if len(body) == 1:
+        name = _expand_ns(name)
+        if '.' in name:
+            ns, _, attr = name.rpartition('.')
+            return (
+                'builtins..setattr',
+                ns,
+                ('quote', attr),
+                body[0],
+            )
         return (
             '.__setitem__',
             ('builtins..globals',),
@@ -104,8 +114,14 @@ def def_(name, *body):
 
 def _decorate(decorators, function):
     for decorator in reversed(decorators):
-        function = decorator, function
+        function = _expand_ns(decorator), function
     return function
+
+
+def _expand_ns(name):
+    if type(name) is str and name.startswith(':'):
+        name = '_ns_.' + name[1:]
+    return name
 
 
 def _is_str(s):
@@ -116,14 +132,13 @@ def _is_str(s):
             pass
 
 
-def function(name, fn, doc=None, qualname=None, annotations=None, dict_=()):
+def function(qualname, fn, doc=None, annotations=None, dict_=()):
     """Enhances a Hissp lambda with function metadata.
     Assigns __doc__, __name__, __qualname__, and __annotations__.
-    (__qualname__ is set to name if qualname is unspecified.)
     Then updates __dict__."""
     fn.__doc__ = doc
-    fn.__name__ = name
-    fn.__qualname__ = qualname or name
+    fn.__name__ = qualname.split('.')[-1]
+    fn.__qualname__ = qualname
     fn.__annotations__ = annotations or {}
     fn.__dict__.update(dict_)
     return fn
@@ -694,3 +709,74 @@ def for_(*exprs):
 def runtime(*forms):
     return ('hebi.basic.._macro_.if_', "(__name__!='<compiler>')",
             (':then', *forms))
+
+
+class attrs(object):
+    """
+    Attribute view proxy of a mapping.
+
+    Provides Lua-like syntactic sugar when the mapping has string
+    keys that are also valid Python identifiers, which is a common
+    occurrence in Python, for example, calling vars() on an object
+    returns such a dict.
+
+    Unlike a SimpleNamespace, an attrs proxy doesn't show the extra
+    magic attrs from the class, and it can write through to any type of
+    mapping.
+
+    >>> spam = {}
+    >>> atspam = attrs(spam)
+
+    get and set string keys as attrs
+    >>> atspam.one = 1
+    >>> atspam.one
+    1
+    >>> atspam
+    attrs({'one': 1})
+
+    changes write through to underlying dict
+    >>> spam
+    {'one': 1}
+
+    calling the object returns the underlying dict for direct access
+    to all dict methods and syntax
+    >>> list(
+    ...  atspam().items()
+    ... )
+    [('one', 1)]
+    >>> atspam()['one'] = 42
+    >>> atspam()
+    {'one': 42}
+
+    del removes the key
+    >>> del atspam.one
+    >>> atspam
+    attrs({})
+    """
+
+    __slots__ = "mapping"
+
+    def __init__(self, mapping):
+        object.__setattr__(self, "mapping", mapping)
+
+    def __call__(self):
+        return object.__getattribute__(self, "mapping")
+
+    def __getattribute__(self, attr):
+        try:
+            return self()[attr]
+        except KeyError as ke:
+            raise AttributeError(*ke.args)
+
+    def __setattr__(self, attr, val):
+        self()[attr] = val
+
+    def __delattr__(self, attr):
+        try:
+            del self()[attr]
+        except KeyError as ke:
+            raise AttributeError(*ke.args)
+
+    def __repr__(self):
+        return "attrs(" + repr(self()) + ")"
+

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -129,29 +129,29 @@ deftype: TestNative pass:TestCase
 def: TestAnd
     type: 'TestAnd' (TestCase,)
         !let: _ns_ :be hebi.bootstrap..attrs: {}
-            def: :test_null: self
+            def: .test_null: self
                 self.assertIs:
                     True
                     and:
-            def: :test_one: self x
+            def: .test_one: self x
                 :@ given: st.from_type: type
                 self.assertIs:
                     x
                     and: x
-            def: :test_two: self x y
+            def: .test_two: self x y
                 :@ given:
                     st.from_type: type
                     st.from_type: type
                 self.assertIs:
                     (x and y)
                     and: x y
-            def: :test_shortcut: self
+            def: .test_shortcut: self
                 and: 0 (0/0)
                 and: 1 0 (0/0)
                 and: 0 (0/0) (0/0)
-            def: :my_given given
-            def: :test_three: self x y z
-                :@ :my_given:  # Try to read decorator from _ns_.
+            def: .my_given given
+            def: .test_three: self x y z
+                :@ .my_given:  # Try to read decorator from _ns_.
                     st.from_type: type
                     st.from_type: type
                     st.from_type: type
@@ -433,33 +433,35 @@ deftype: TestLoop pass:TestCase
                 if: (c=='C') :then: break: c
                 :else: 'z'
 
-
 def: TestBegin
-    type: 'TestBegin' (TestCase,)
-        !let: _ns_ :be hebi.bootstrap..attrs: {}
-            def: :test_begin: self
-                !let: xs :be []
-                    self.assertEqual:
-                        3
-                        !begin:
-                            xs.append: 1
-                            xs.append: 2
+    types..new_class: 'TestBegin' (TestCase,) None
+        lambda: pass: xAUTO0_
+            !let: _ns_ :be hebi.bootstrap..attrs: xAUTO0_
+                def: .__doc__ "Test Begin Docstring."
+                def: .__module__ operator..getitem: pass:globals '__name__'
+                def: .test_begin: self
+                    !let: xs :be []
+                        self.assertEqual:
                             3
-                    self.assertEqual: xs [1, 2]
-            def: :test_begin_empty: self
-                self.assertEqual:
-                    ()
-                    !begin:
-            def: :test_begin0: self
-                !let: xs :be []
+                            !begin:
+                                xs.append: 1
+                                xs.append: 2
+                                3
+                        self.assertEqual: xs [1, 2]
+                def: .test_begin_empty: self
                     self.assertEqual:
-                        0
-                        !begin0:
+                        ()
+                        !begin:
+                def: .test_begin0: self
+                    !let: xs :be []
+                        self.assertEqual:
                             0
-                            xs.append: 1
-                            xs.append: 2
-                    self.assertEqual: xs [1, 2]
-            _ns_:
+                            !begin0:
+                                0
+                                xs.append: 1
+                                xs.append: 2
+                        self.assertEqual: xs [1, 2]
+                _ns_:
 
 # TODO: test try
 

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -126,41 +126,38 @@ deftype: TestNative pass:TestCase
                     :else:
                         print: "nan"
 
-deftype: TestAnd pass:TestCase
-    test_null lambda: self:
-        self.assertIs:
-            True
-            and:
-    test_one pass:
-        given: st.from_type: type
-        function: quote:test_one
-            lambda: self: x
+def: TestAnd
+    type: 'TestAnd' (TestCase,)
+        !let: _ns_ :be hebi.bootstrap..attrs: {}
+            def: :test_null: self
+                self.assertIs:
+                    True
+                    and:
+            def: :test_one: self x
+                :@ given: st.from_type: type
                 self.assertIs:
                     x
                     and: x
-    test_two pass:
-        given:
-            st.from_type: type
-            st.from_type: type
-        function: quote:test_two
-            lambda: self: x y
+            def: :test_two: self x y
+                :@ given:
+                    st.from_type: type
+                    st.from_type: type
                 self.assertIs:
                     (x and y)
                     and: x y
-    test_shortcut lambda: self:
-        and: 0 (0/0)
-        and: 1 0 (0/0)
-        and: 0 (0/0) (0/0)
-    test_three pass:
-        given:
-            st.from_type: type
-            st.from_type: type
-            st.from_type: type
-        function: quote:test_three
-            lambda: self: x y z
+            def: :test_shortcut: self
+                and: 0 (0/0)
+                and: 1 0 (0/0)
+                and: 0 (0/0) (0/0)
+            def: :test_three: self x y z
+                :@ given:
+                    st.from_type: type
+                    st.from_type: type
+                    st.from_type: type
                 self.assertIs:
                     (x and y and z)
                     and: x y z
+            _ns_:
 
 deftype: TestOr pass:TestCase
     test_null lambda: self:
@@ -436,29 +433,32 @@ deftype: TestLoop pass:TestCase
                 :else: 'z'
 
 
-deftype: TestBegin pass:TestCase
-    test_begin lambda: self:
-        !let: xs :be []
-            self.assertEqual:
-                3
-                !begin:
-                    xs.append: 1
-                    xs.append: 2
-                    3
-            self.assertEqual: xs [1, 2]
-    test_begin_empty lambda: self:
-        self.assertEqual:
-            ()
-            !begin:
-    test_begin0 lambda: self:
-        !let: xs :be []
-            self.assertEqual:
-                0
-                !begin0:
-                    0
-                    xs.append: 1
-                    xs.append: 2
-            self.assertEqual: xs [1, 2]
+def: TestBegin
+    type: 'TestBegin' (TestCase,)
+        !let: _ns_ :be hebi.bootstrap..attrs: {}
+            def: :test_begin: self
+                !let: xs :be []
+                    self.assertEqual:
+                        3
+                        !begin:
+                            xs.append: 1
+                            xs.append: 2
+                            3
+                    self.assertEqual: xs [1, 2]
+            def: :test_begin_empty: self
+                self.assertEqual:
+                    ()
+                    !begin:
+            def: :test_begin0: self
+                !let: xs :be []
+                    self.assertEqual:
+                        0
+                        !begin0:
+                            0
+                            xs.append: 1
+                            xs.append: 2
+                    self.assertEqual: xs [1, 2]
+            _ns_:
 
 # TODO: test try
 

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -149,8 +149,9 @@ def: TestAnd
                 and: 0 (0/0)
                 and: 1 0 (0/0)
                 and: 0 (0/0) (0/0)
+            def: :my_given given
             def: :test_three: self x y z
-                :@ given:
+                :@ :my_given:  # Try to read decorator from _ns_.
                     st.from_type: type
                     st.from_type: type
                     st.from_type: type

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -433,6 +433,28 @@ deftype: TestLoop pass:TestCase
                 if: (c=='C') :then: break: c
                 :else: 'z'
 
+def: TestDef
+    types..new_class: 'TestDef' (TestCase,) None
+        lambda: pass: xAUTO0_
+            !let: _ns_ :be hebi.bootstrap..attrs: xAUTO0_
+                def: .__module__ operator..getitem: pass:globals '__name__'
+                def: .test_def_ns: self
+                    """ How to emulate local reassignment. """
+                    !let: o :be types..SimpleNamespace:
+                        def: o.foo 2
+                        def: o.foo (o.foo * 3)
+                        self.assertEqual:
+                            6
+                            o.foo
+                def: .test_def_anaphoric_ns: self
+                    !let: _ns_ :be types..SimpleNamespace:
+                        def: .foo 2
+                        def: .foo (_ns_.foo * 3)
+                        self.assertEqual:
+                            6
+                            _ns_.foo
+                _ns_:
+
 def: TestBegin
     types..new_class: 'TestBegin' (TestCase,) None
         lambda: pass: xAUTO0_
@@ -461,6 +483,14 @@ def: TestBegin
                                 xs.append: 1
                                 xs.append: 2
                         self.assertEqual: xs [1, 2]
+                def: .test_def_ns: self
+                    """ How to emulate local reassignment. """
+                    !let: ns :be types..SimpleNamespace:
+                        def: ns.foo 2
+                        def: ns.foo (ns.foo * 3)
+                        self.assertEqual:
+                            6
+                            ns.foo
                 _ns_:
 
 # TODO: test try


### PR DESCRIPTION
Related to #7.

Allow `def:` to define an attribute of a namespace instead of just globals.