### PR TITLE
Implement !of: macro

### DIFF
--- a/src/hebi/basic/_macro_.py
+++ b/src/hebi/basic/_macro_.py
@@ -20,4 +20,5 @@ from ..bootstrap import (
     break_,
     continue_,
     runtime,
+    of,
 )

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -864,3 +864,12 @@ class attrs(object):
     def __repr__(self):
         return "attrs(" + repr(self()) + ")"
 
+
+def of(*exprs):
+    *keys, collection = exprs
+    for key in reversed(keys):
+        if type(key) is str and not key.startswith('('):
+            collection = ('builtins..getattr', collection, ('quote', key),)
+        else:
+            collection = ('operator..getitem', collection, key)
+    return collection

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -868,8 +868,8 @@ class attrs(object):
 def of(*exprs):
     *keys, collection = exprs
     for key in reversed(keys):
-        if type(key) is str and not key.startswith('('):
-            collection = ('builtins..getattr', collection, ('quote', key),)
+        if type(key) is str and key.startswith('.'):
+            collection = ('builtins..getattr', collection, ('quote', key[1:]),)
         else:
             collection = ('operator..getitem', collection, key)
     return collection

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -500,7 +500,8 @@ class: TestClass: TestCase
     def: .test_class_in_method_qualname: self
         self.assertEqual:
             'o.Bacon'
-            (self.Spam().eggs().__qualname__)
+            # (self.Spam().eggs().__qualname__)
+            !of: __qualname__ .eggs: .Spam: self
     def: .test_doc: self
         self.assertEqual:
             """Test doc"""
@@ -520,6 +521,21 @@ class: TestClass: TestCase
                     super:
                     None
             o.Spam:
+
+class: TestOf: TestCase
+    def: .test_symbol: self
+        !let: o :be types..SimpleNamespace: : a 1  b 2
+            self.assertEqual: 1 !of: a o
+            self.assertEqual: 2 !of: b o
+    def: .test_key: self
+        !let: d :be {'a':1, 10:2}
+            self.assertEqual: 1 !of: 'a' d
+            self.assertEqual: 2 !of: 10 d
+    def: .test_chained: self
+        self.assertEqual:
+            42
+            # types.SimpleNamespace(attr=[0, {'key': -42}]).attr[1]['key'].__neg__()
+            .__neg__:!of: 'key' 1 attr types..SimpleNamespace: : attr [0, {'key': -42}]
 
 # TODO: test try
 

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -501,7 +501,7 @@ class: TestClass: TestCase
         self.assertEqual:
             'o.Bacon'
             # (self.Spam().eggs().__qualname__)
-            !of: __qualname__ .eggs: .Spam: self
+            !of: .__qualname__ .eggs: .Spam: self
     def: .test_doc: self
         self.assertEqual:
             """Test doc"""
@@ -525,17 +525,22 @@ class: TestClass: TestCase
 class: TestOf: TestCase
     def: .test_symbol: self
         !let: o :be types..SimpleNamespace: : a 1  b 2
-            self.assertEqual: 1 !of: a o
-            self.assertEqual: 2 !of: b o
+            self.assertEqual: 1 !of: .a o
+            self.assertEqual: 2 !of: .b o
     def: .test_key: self
-        !let: d :be {'a':1, 10:2}
-            self.assertEqual: 1 !of: 'a' d
+        !let: d :be {'.a':1, 10:2}
+            self.assertEqual: 1 !of: '.a' d
             self.assertEqual: 2 !of: 10 d
     def: .test_chained: self
         self.assertEqual:
             42
             # types.SimpleNamespace(attr=[0, {'key': -42}]).attr[1]['key'].__neg__()
-            .__neg__:!of: 'key' 1 attr types..SimpleNamespace: : attr [0, {'key': -42}]
+            .__neg__:!of: 'key' 1 .attr types..SimpleNamespace: : attr [0, {'key': -42}]
+    def: .test_identifier: self
+        self.assertEqual:
+            3.0
+            !let: i :be 2
+                !of: .imag i [1j,2j,3j]
 
 # TODO: test try
 


### PR DESCRIPTION
Gets attrs or items from an object. Can chain multiple keys/identifiers. The prefix ordering is the opposite of what Python uses, but it's more consistent with function applications. Unary functions (including "nullary" methods with the `.foo: self` syntax) compose very naturally with `!of:` this way. See tests for examples.