### PR TITLE
del: macro

### DIFF
--- a/src/hebi/basic/_macro_.py
+++ b/src/hebi/basic/_macro_.py
@@ -22,4 +22,5 @@ from ..bootstrap import (
     runtime,
     of,
     attach,
+    del_,
 )

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -494,10 +494,15 @@ def _qualify(symbol):
 
 
 def _begin(*body):
-    return body and body[-1]
+    return body[-1]
 
 
 def begin(*body):
+    case = len(body)
+    if case == 0:
+        return ()
+    if case == 1:
+        return body[0]
     return (BOOTSTRAP + '_begin', *body)
 
 
@@ -506,6 +511,8 @@ def _begin0(zero, *body):
 
 
 def begin0(*body):
+    if len(body) == 1:
+        return body[0]
     return (BOOTSTRAP + '_begin0', *body)
 
 

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -895,13 +895,17 @@ def attach(target, *args):
 def del_(*args):
     return (
         BOOTSTRAP + 'begin',
-        *(
-            ('builtins..delattr', *(lambda x, y:[x,('quote',y)])(*arg.rsplit('.', 1)),)
-            if '.' in arg
-            else ('operator..delitem',
-                  ('globals',),
-                  ('quote', arg,),)
-            for arg in ('_ns_'+a if a.startswith('.') else a for a in args)
-        ),
+        *_del_(args),
         (),
     )
+
+
+def _del_(args):
+    for arg in args:
+        if '.' in arg:
+            if arg.startswith('.'):
+                arg = '_ns_'+arg
+            o, attr = arg.rsplit('.', 1)
+            yield ('builtins..delattr', o, ('quote', attr,),)
+        else:
+            yield ('operator..delitem', ('globals',), ('quote', arg,),)

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -891,3 +891,17 @@ def attach(target, *args):
         *iargs,
     )
 
+
+def del_(*args):
+    return (
+        BOOTSTRAP + 'begin',
+        *(
+            ('builtins..delattr', *(lambda x, y:[x,('quote',y)])(*arg.rsplit('.', 1)),)
+            if '.' in arg
+            else ('operator..delitem',
+                  ('globals',),
+                  ('quote', arg,),)
+            for arg in ('_ns_'+a if a.startswith('.') else a for a in args)
+        ),
+        (),
+    )

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -96,7 +96,7 @@ def def_(name, *body):
     if len(body) == 1:
         name = _expand_ns(name)
         if '.' in name:
-            ns, _, attr = name.rpartition('.')
+            ns, attr = name.rsplit('.', 1)
             return (
                 'builtins..setattr',
                 ns,

--- a/src/hebi/bootstrap.py
+++ b/src/hebi/bootstrap.py
@@ -878,6 +878,7 @@ def of(*exprs):
 def _attach(target, **kwargs):
     for k, v in kwargs.items():
         setattr(target, k, v)
+    return target
 
 
 def attach(target, *args):

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -551,6 +551,50 @@ class: TestAttach: TestCase
                 types..SimpleNamespace: : foo 1  bar 2  baz 3  quux 4  norlf 5
                 o
 
+class: TestDel: TestCase
+    def: .setUp: self
+        !let: _ns_ :be self
+            def: .delete_me 'foo delete'
+        def: DELETE_ME 'bar delete'
+        def: self.o types..SimpleNamespace:
+        def: self.o.foo 2
+    def: .test_del_ns: self
+        self.assertIn: 'delete_me' vars:self
+        !let: _ns_ :be self
+            del: .delete_me
+        self.assertNotIn: 'delete_me' vars:self
+    def: .test_del_global: self
+        self.assertIn: 'DELETE_ME' globals:
+        del: DELETE_ME
+        self.assertNotIn: 'DELETE_ME' globals:
+    def: .test_del_attr: self
+        !let: o :be types..SimpleNamespace: : a 1
+            self.assertIn: 'a' vars:o
+            del: o.a
+            self.assertNotIn: 'a' vars:o
+    def: .test_del_empty: self
+        del:
+    def: .test_del_multiple: self
+        !let: :,: _ns_ o
+            :be !mask:pass: :,:self :,:types..SimpleNamespace: : a 1  b 2  c 3
+            del: DELETE_ME .delete_me o.a
+            self.assertNotIn: 'a' vars:o
+            self.assertEqual:
+                types..SimpleNamespace: : b 2  c 3
+                o
+        self.assertNotIn: 'delete_me' vars:self
+        self.assertNotIn: 'DELETE_ME' globals:
+    def: .test_del_nested: self
+        self.assertEqual:
+            types..SimpleNamespace: : foo 2
+            self.o
+        del: self.o.foo
+        self.assertEqual:
+            types..SimpleNamespace:
+            self.o
+
+
+
 # TODO: test try
 
 #def: __package__ "tests.native_hebi_tests"

--- a/tests/native_hebi_tests/native_tests.hebi
+++ b/tests/native_hebi_tests/native_tests.hebi
@@ -546,7 +546,9 @@ class: TestAttach: TestCase
     def: .test_attach: self
         !let: :,: foo bar baz spam eggs o
             :be hebi.bootstrap..entuple: 1 2 3 4 5 types..SimpleNamespace:
-            !attach: o foo bar baz : quux spam  norlf eggs
+            self.assertIs:
+                o
+                !attach: o foo bar baz : quux spam  norlf eggs
             self.assertEqual:
                 types..SimpleNamespace: : foo 1  bar 2  baz 3  quux 4  norlf 5
                 o


### PR DESCRIPTION
`del:` should work similarly to `def:`, but it can take multiple arguments. This is for object attributes (including `_ns_` and module globals), but doesn't otherwise delete items in mappings. Use `operator..delattr` for that instead.

Also some tweaks to older macros.
 - `attach` (which I just wrote today) now returns its target object.
 - `begin` (and `begin0`) now have simpler expansions for small cases.