### PR TITLE
Basic REPL via Jupyter kernel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 hissp
+jupyter-console
 
 # Required for testing only.
 hypothesis

--- a/src/hebi/__main__.py
+++ b/src/hebi/__main__.py
@@ -1,0 +1,13 @@
+import subprocess
+import time
+
+from jupyter_console import app
+
+kernel = subprocess.Popen(["python", "-m", "hebi.kernel"])
+
+time.sleep(1)  # TODO: this seems brittle.
+app.launch_new_instance(
+    argv=["jupyter", "console", "--existing", f"kernel-{kernel.pid}.json"]
+)
+print("killing kernel")
+kernel.kill()

--- a/src/hebi/__main__.py
+++ b/src/hebi/__main__.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import subprocess
 import time
 

--- a/src/hebi/kernel.py
+++ b/src/hebi/kernel.py
@@ -9,10 +9,10 @@ from hebi import parser
 
 class HebigoKernel(Kernel):
     implementation = "hebigo"
-    implementation_version = "hebigo"
+    implementation_version = "0.1.0"
     language = "hebigo"
-    language_version = "hebigo"
-    banner = "hebigo"
+    language_version = "0.1.0"
+    banner = "Hebigo kernel"
 
     language_info = {"mimetype": "text/hebigo", "file_extension": "hebi"}
 

--- a/src/hebi/kernel.py
+++ b/src/hebi/kernel.py
@@ -1,8 +1,8 @@
 import traceback
 from typing import Optional
 
-from ipykernel.kernelbase import Kernel
 from hissp.compiler import Compiler
+from ipykernel.kernelbase import Kernel
 
 from hebi import parser
 

--- a/src/hebi/kernel.py
+++ b/src/hebi/kernel.py
@@ -51,6 +51,8 @@ class HebigoKernel(Kernel):
                 compile(self.compiler.compile(parser.reads(code)), "<repl>", "single"),
                 self.compiler.ns,
             )
+        except SystemExit:
+            raise  # TODO: how do we shut down properly?
         except:
             if not silent:
                 self.send_response(

--- a/src/hebi/kernel.py
+++ b/src/hebi/kernel.py
@@ -47,35 +47,35 @@ class HebigoKernel(Kernel):
         # send_response(). See Messaging in IPython for details of the
         # different message types.
         try:
-            result = self.compiler.compile(parser.reads(code))
+            exec(
+                compile(self.compiler.compile(parser.reads(code)), "<repl>", "single"),
+                self.compiler.ns,
+            )
         except:
             if not silent:
                 self.send_response(
                     self.iopub_socket,
-                    'stream',
-                    {'name': 'stderr', 'text': traceback.format_exc()})
-        else:
-            if not silent:
-                stream_content = {'name': 'stdout', 'text': result}
-                self.send_response(self.iopub_socket, 'stream', stream_content)
+                    "stream",
+                    {"name": "stderr", "text": traceback.format_exc()},
+                )
 
         return {
-            'status': 'ok',
-            'execution_count': self.execution_count,
-            'payload': [],  # Deprecated?
-            'user_expressions': {},  # Unused?
+            "status": "ok",
+            "execution_count": self.execution_count,
+            "payload": [],  # Deprecated?
+            "user_expressions": {},  # Unused?
         }
 
     def do_is_complete(self, code: str):
-        status = 'incomplete'
-        if ':' not in code or code.endswith('\n'):
-            status = 'complete'
+        status = "incomplete"
+        if ":" not in code or code.endswith("\n"):
+            status = "complete"
         try:
             list(parser.reads(code))
         except:
-            status = 'incomplete'
-        assert status in {'complete', 'incomplete', 'invalid', 'unknown'}
-        return {'status': status}
+            status = "incomplete"
+        assert status in {"complete", "incomplete", "invalid", "unknown"}
+        return {"status": status}
 
 
 if __name__ == "__main__":

--- a/src/hebi/kernel.py
+++ b/src/hebi/kernel.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import traceback
 from typing import Optional
 
@@ -33,12 +37,11 @@ class HebigoKernel(Kernel):
         silent (bool) – Whether to display output.
         store_history (bool) – Whether to record this code in history
             and increase the execution count. If silent is True, this
-            is implicitly False.
+            is implicitly False. Currently ignored.
         user_expressions (dict) – Mapping of names to expressions to
-            evaluate after the code has run. You can ignore this if
-            you need to.
+            evaluate after the code has run. Currently ignored.
         allow_stdin (bool) – Whether the frontend can provide input on
-            request (e.g. for Python’s raw_input()).
+            request (e.g. for Python’s raw_input()). Currently ignored.
 
         returns a dict containing the fields described in Execution
         results.

--- a/src/hebi/kernel.py
+++ b/src/hebi/kernel.py
@@ -1,0 +1,70 @@
+from typing import Optional
+
+from ipykernel.kernelbase import Kernel
+
+from hebi import parser
+
+
+class HebigoKernel(Kernel):
+    implementation = "hebigo"
+    implementation_version = "hebigo"
+    language = "hebigo"
+    language_version = "hebigo"
+    banner = "hebigo"
+
+    language_info = {"mimetype": "text/hebigo", "file_extension": "hebi"}
+
+    def do_execute(
+        self,
+        code: str,
+        silent: bool,
+        store_history: bool = True,
+        user_expressions: Optional[dict] = None,
+        allow_stdin: bool = False,
+    ):
+        """
+        code (str) – The code to be executed.
+        silent (bool) – Whether to display output.
+        store_history (bool) – Whether to record this code in history
+            and increase the execution count. If silent is True, this
+            is implicitly False.
+        user_expressions (dict) – Mapping of names to expressions to
+            evaluate after the code has run. You can ignore this if
+            you need to.
+        allow_stdin (bool) – Whether the frontend can provide input on
+            request (e.g. for Python’s raw_input()).
+
+        returns a dict containing the fields described in Execution
+        results.
+        """
+        # To display output, it can send messages using
+        # send_response(). See Messaging in IPython for details of the
+        # different message types.
+        result = str(list(parser.reads(code)))
+        if not silent:
+            stream_content = {'name': 'stdout', 'text': result}
+            self.send_response(self.iopub_socket, 'stream', stream_content)
+
+        return {
+            'status': 'ok',
+            'execution_count': self.execution_count,
+            'payload': [],  # Deprecated?
+            'user_expressions': {},  # Unused?
+        }
+
+    def do_is_complete(self, code: str):
+        status = 'incomplete'
+        if ':' not in code or code.endswith('\n'):
+            status = 'complete'
+        try:
+            list(parser.reads(code))
+        except:
+            status = 'incomplete'
+        assert status in {'complete', 'incomplete', 'invalid', 'unknown'}
+        return {'status': status}
+
+
+if __name__ == "__main__":
+    from ipykernel.kernelapp import IPKernelApp
+
+    IPKernelApp.launch_instance(kernel_class=HebigoKernel)

--- a/src/hebi/kernel.py
+++ b/src/hebi/kernel.py
@@ -68,7 +68,7 @@ class HebigoKernel(Kernel):
 
     def do_is_complete(self, code: str):
         status = "incomplete"
-        if ":" not in code or code.endswith("\n"):
+        if ": " not in code and not code.endswith(':') or code.endswith("\n"):
             status = "complete"
         try:
             list(parser.reads(code))

--- a/src/hebi/parser.py
+++ b/src/hebi/parser.py
@@ -206,21 +206,3 @@ def transpile_module(
             f.write(compiler.Compiler(qualsymbol, evaluate=True).compile(hissp))
 
 
-code = '''\
-test_default_strs lambda: self:
-    self.assertEqual:
-        ['ab', 22, 33]
-        !let:
-            :=: :strs: a b c
-                :default: a ('a'+'b')
-            {'b':22,'c':33}
-            [a, b, c]
-'''
-
-for k, v in lex(code):
-    print(k, repr(v))
-
-
-pprint(list(reads(code)))
-
-print('DONE')


### PR DESCRIPTION
It's the main function of the package, so you can start it with 
```
$ python -m hebi
```
The documentation for IPython wrapper kernels seems inadequate, so this has pretty basic functionality. It's also isn't exiting cleanly. It's still a bit better than what Lissp has though.